### PR TITLE
Ignores rulers-\*.gem files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@
 
 # rspec failure tracking
 .rspec_status
+
+rulers-*.gem


### PR DESCRIPTION
We don't need to add .gem files in the codebase. Adding this to .gitignore ensures we do not do it.